### PR TITLE
Enforce HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ A single page app for viewing trains going to Europe.
 - Customise compression to ignore files under a certain size
 - Set up an SSL cert
 - Add routing for next sub-app
+- Force HTTPS
 - ~~Heroku notification to Slack on Production deployments~~
 - ~~Pre-commit hook to run Prettier~~
 - ~~Start using styled-tools~~

--- a/app.json
+++ b/app.json
@@ -1,7 +1,5 @@
 {
-  "addons": [
-
-  ],
+  "addons": [],
   "buildpacks": [
     {
       "url": "heroku/nodejs"
@@ -11,6 +9,10 @@
     "CONFIG_ENV": {
       "value": "review",
       "required": true
+    },
+    "ENFORCE_HTTPS": {
+      "value": "true",
+      "required": true
     }
   },
   "formation": {
@@ -19,7 +21,6 @@
     }
   },
   "name": "europeanstar",
-  "scripts": {
-  },
+  "scripts": {},
   "stack": "heroku-18"
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "directory-tree": "^2.2.1",
     "fecha": "^3.0.2",
     "koa": "^2.7.0",
+    "koa-sslify": "^4.0.3",
     "koa-static": "^5.0.0",
     "react": "^16.8.5",
     "react-datepicker": "^2.3.0",

--- a/scripts/server.js
+++ b/scripts/server.js
@@ -1,12 +1,12 @@
 const Koa = require("koa")
 const static = require("koa-static")
-const { default: sslify } = require("koa-sslify")
+const { default: sslify, xForwardedProtoResolver } = require("koa-sslify")
 const app = new Koa()
 
 require("./config")
 
 if (process.env.ENFORCE_HTTPS === "true") {
-  app.use(sslify({ trustProtoHeader: true }))
+  app.use(sslify({ resolver: xForwardedProtoResolver }))
 }
 
 app.use(

--- a/scripts/server.js
+++ b/scripts/server.js
@@ -1,11 +1,16 @@
 const Koa = require("koa")
-const koaStatic = require("koa-static")
+const static = require("koa-static")
+const sslify = require("koa-sslify")
 const app = new Koa()
 
 require("./config")
 
+if (process.env.ENFORCE_HTTPS === "true") {
+  app.use(sslify({ trustProtoHeader: true }))
+}
+
 app.use(
-  koaStatic("build", {
+  static("build", {
     gzip: true,
     br: true,
     maxage: 31536000000, // Cache everything...

--- a/scripts/server.js
+++ b/scripts/server.js
@@ -1,6 +1,6 @@
 const Koa = require("koa")
 const static = require("koa-static")
-const sslify = require("koa-sslify")
+const { default: sslify } = require("koa-sslify")
 const app = new Koa()
 
 require("./config")

--- a/yarn.lock
+++ b/yarn.lock
@@ -6184,6 +6184,11 @@ koa-send@^5.0.0:
     mz "^2.7.0"
     resolve-path "^1.4.0"
 
+koa-sslify@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.npmjs.org/koa-sslify/-/koa-sslify-4.0.3.tgz#79ec31042a607d0c4c0a32e21cea513708840c1c"
+  integrity sha512-5RwsRc+Zkawoq9ev5pNAPP8r+wj4Eqo3b7IfSXrpYISBDNo0fwrMcYMioR+B00piV9NpXqPZA4gh36SpIeZSvw==
+
 koa-static@^5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/koa-static/-/koa-static-5.0.0.tgz#5e92fc96b537ad5219f425319c95b64772776943"


### PR DESCRIPTION
When serving the app via Koa, force http requests to be redirected to https.

Based on the environment variable, `ENFORCE_HTTPS`.